### PR TITLE
node24 support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,6 @@ outputs:
   console-url:
     description: 'The AWS Console URL for the test run'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
This brings node24 support to the action and allows getting rid of the warning with recent actions runners

>Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: **aws-actions/aws-devicefarm-mobile-device-testing**@v2.3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/